### PR TITLE
Add sample PR template to streamline contributions

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,0 +1,24 @@
+## Type of Change
+
+(Bug fix, new feature, documentation, configuration update, etc.)
+
+## Context
+
+[Insert the issue number or link to the related issue, if applicable]
+
+## Changes Made
+
+- [Insert a bullet point list of the changes made in this pull request]
+
+## Screenshots and Testing
+
+[Insert any relevant screenshots, if applicable]
+
+## Checklist
+
+- [ ] I have tested these changes locally
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have updated the documentation, if applicable
+- [ ] I have added unit tests, if applicable


### PR DESCRIPTION
## Type of Change

Documentation Update

## Context

We need a sample PR template in order to ensure the team has a somewhat standardized system of streamlining contribution

## Changes Made

-Added a PR template to the project in `docs/pull_request_template.md`
- This can be changed later :) 

## Screenshots and Testing

N/A

## Checklist

- [x] I have tested these changes locally
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation, if applicable
- [x] I have added unit tests, if applicable